### PR TITLE
clarify/document scoped()'s deprecation (closes #5)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "thread-scoped"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["arcnmx", "The Rust Project Developers"]
 
-description = "Stable std::thread::scoped"
+description = "Unsafe and deprecated std::thread::scoped"
 documentation = "http://arcnmx.github.io/thread-scoped-rs/thread_scoped/"
 repository = "https://github.com/arcnmx/thread-scoped-rs"
 readme = "README.md"
-keywords = ["thread", "scoped", "spawn", "stable"]
+keywords = ["thread", "scoped", "spawn"]
 license = "MIT/Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -5,9 +5,24 @@
 A `std::thread::spawn()` that can access its current scope.
 Stable fork of the deprecated `std::thread::scoped()`
 
+
+## Unsafe Warning
+
+This interface is inherently unsafe if the `JoinGuard` is allowed to leak without being dropped.
+See [rust-lang/rust#24292](https://github.com/rust-lang/rust/issues/24292) for more details.
+
+
+## Alternatives
+
+This crate is only provided as a fallback mirror for legacy dependency on the
+deprecated `libstd` interface. Using a modern safe API instead is recommended:
+
+- [crossbeam::scope](https://github.com/crossbeam-rs/crossbeam)
+
+
 [travis-badge]: https://img.shields.io/travis/arcnmx/thread-scoped-rs/master.svg?style=flat-square
 [travis]: https://travis-ci.org/arcnmx/thread-scoped-rs
-[release-badge]: https://img.shields.io/github/release/arcnmx/thread-scoped-rs.svg?style=flat-square
+[release-badge]: https://img.shields.io/crates/v/thread_scoped.svg?style=flat-square
 [cargo]: https://crates.io/crates/thread-scoped
 [docs-badge]: https://img.shields.io/badge/API-docs-blue.svg?style=flat-square
 [docs]: http://arcnmx.github.io/thread-scoped-rs/thread_scoped/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A `std::thread::spawn()` that can access its current scope.
 Stable fork of the deprecated `std::thread::scoped()`
 
 
-## Unsafe Warning
+## Memory Unsafety
 
 This interface is inherently unsafe if the `JoinGuard` is allowed to leak without being dropped.
 See [rust-lang/rust#24292](https://github.com/rust-lang/rust/issues/24292) for more details.
@@ -15,7 +15,7 @@ See [rust-lang/rust#24292](https://github.com/rust-lang/rust/issues/24292) for m
 ## Alternatives
 
 This crate is only provided as a fallback mirror for legacy dependency on the
-deprecated `libstd` interface. Using a modern safe API instead is recommended:
+deprecated `libstd` interface. Using a modern and safe API instead is recommended:
 
 - [crossbeam::scope](https://github.com/crossbeam-rs/crossbeam)
 


### PR DESCRIPTION
bump version so we can redeploy to crates.io